### PR TITLE
Add Signer API

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ Goal
 
 ## Getting started
 
-See `test/mcl.test.ts` for sample usage.
+See `test/signer.test.ts` for sample usage.

--- a/src/exceptions.ts
+++ b/src/exceptions.ts
@@ -18,6 +18,8 @@ export class MismatchLength extends MclError {}
 
 export class BadMessage extends MclError {}
 
+export class BadHex extends MclError {}
+
 // SignerError
 
 export class NullSigner extends SignerError {}

--- a/src/exceptions.ts
+++ b/src/exceptions.ts
@@ -1,0 +1,23 @@
+export class HubbleBlsError extends Error {}
+
+export class HashToFieldError extends HubbleBlsError {}
+
+export class MclError extends HubbleBlsError {}
+
+export class SignerError extends HubbleBlsError {}
+
+// HashToFieldError
+
+export class BadDomain extends HashToFieldError {}
+
+// MclError
+
+export class EmptyArray extends MclError {}
+
+export class MismatchLength extends MclError {}
+
+export class BadMessage extends MclError {}
+
+// SignerError
+
+export class NullSigner extends SignerError {}

--- a/src/hashToField.ts
+++ b/src/hashToField.ts
@@ -1,5 +1,6 @@
 import { BigNumber } from "ethers";
 import { sha256, arrayify, zeroPad } from "ethers/lib/utils";
+import { BadDomain } from "./exceptions";
 
 export const FIELD_ORDER = BigNumber.from(
     "0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47"
@@ -27,9 +28,8 @@ export function expandMsg(
     msg: Uint8Array,
     outLen: number
 ): Uint8Array {
-    if (domain.length > 32) {
-        throw new Error("bad domain size");
-    }
+    if (domain.length > 32)
+        throw new BadDomain(`Expect 32 bytes but got ${domain.length}`);
 
     const out: Uint8Array = new Uint8Array(outLen);
 

--- a/src/mcl.ts
+++ b/src/mcl.ts
@@ -4,6 +4,7 @@ import { hashToField } from "./hashToField";
 import { arrayify, hexlify, randomBytes, isHexString } from "ethers/lib/utils";
 import {
     BadDomain,
+    BadHex,
     BadMessage,
     EmptyArray,
     MismatchLength,
@@ -202,6 +203,13 @@ export function randG1(): solG1 {
 
 export function randG2(): solG2 {
     return g2ToHex(randMclG2());
+}
+
+export function parseFr(hex: string) {
+    if (!isHexString(hex)) throw new BadHex(`Expect hex but got ${hex}`);
+    const fr = new mcl.Fr();
+    fr.setHashOf(hex);
+    return fr;
 }
 
 export function parseG1(solG1: solG1): mclG1 {

--- a/src/mcl.ts
+++ b/src/mcl.ts
@@ -1,13 +1,7 @@
 const mcl = require("mcl-wasm");
 import { BigNumber } from "ethers";
 import { hashToField } from "./hashToField";
-import {
-    arrayify,
-    hexlify,
-    randomBytes,
-    toUtf8Bytes,
-    isHexString,
-} from "ethers/lib/utils";
+import { arrayify, hexlify, randomBytes, isHexString } from "ethers/lib/utils";
 
 export const FIELD_ORDER = BigNumber.from(
     "0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47"
@@ -17,10 +11,10 @@ export type mclG2 = any;
 export type mclG1 = any;
 export type mclFP = any;
 export type mclFR = any;
-export type PublicKey = solG2;
 export type SecretKey = mclFR;
+export type MessagePoint = mclG1;
 export type Signature = mclG1;
-export type Message = solG1;
+export type PublicKey = mclG2;
 
 export type solG1 = [string, string];
 export type solG2 = [string, string, string, string];
@@ -30,31 +24,26 @@ export interface keyPair {
     secret: SecretKey;
 }
 
-let DOMAIN: Uint8Array;
+export type Domain = Uint8Array;
 
 export async function init() {
     await mcl.init(mcl.BN_SNARK1);
-    mcl.setMapToMode(0);
+    mcl.setMapToMode(mcl.BN254);
 }
 
-export function setDomain(domain: string) {
-    DOMAIN = toUtf8Bytes(domain);
-}
-
-export function setDomainHex(domain: string) {
-    DOMAIN = arrayify(domain);
-    if (DOMAIN.length != 32) {
+export function validateDomain(domain: Domain) {
+    if (domain.length != 32) {
         throw new Error("bad domain length");
     }
 }
 
-export function hashToPoint(msg: string): mclG1 {
+export function hashToPoint(msg: string, domain: Domain): MessagePoint {
     if (!isHexString(msg)) {
         throw new Error("message is expected to be hex string");
     }
 
     const _msg = arrayify(msg);
-    const [e0, e1] = hashToField(DOMAIN, _msg, 2);
+    const [e0, e1] = hashToField(domain, _msg, 2);
     const p0 = mapToPoint(e0);
     const p1 = mapToPoint(e1);
     const p = mcl.add(p0, p1);
@@ -114,82 +103,72 @@ export function g2ToHex(p: mclG2): solG2 {
     return [x0, x1, y0, y1];
 }
 
+export function getPubkey(secret: SecretKey): PublicKey {
+    const pubkey = mcl.mul(g2(), secret);
+    pubkey.normalize();
+    return pubkey;
+}
+
 export function newKeyPair(): keyPair {
     const secret = randFr();
-    const mclPubkey = mcl.mul(g2(), secret);
-    mclPubkey.normalize();
-    const pubkey = g2ToHex(mclPubkey);
+    const pubkey = getPubkey(secret);
     return { pubkey, secret };
 }
 
 export function sign(
     message: string,
-    secret: SecretKey
-): {
-    signature: Signature;
-    M: Message;
-} {
-    const messagePoint = hashToPoint(message);
+    secret: SecretKey,
+    domain: Domain
+): { signature: Signature; messagePoint: MessagePoint } {
+    const messagePoint = hashToPoint(message, domain);
     const signature = mcl.mul(messagePoint, secret);
     signature.normalize();
-    const M = g1ToHex(messagePoint);
-    return { signature, M };
+    return { signature, messagePoint };
 }
 
-export function verify(
-    signature: solG1,
-    pubkey: solG2,
-    message: Message
+export function verifyRaw(
+    signature: Signature,
+    pubkey: PublicKey,
+    message: MessagePoint
 ): boolean {
     const negG2 = new mcl.PrecomputedG2(negativeG2());
-    const messageG1 = parseG1(message);
-    const pubkeyG2 = parseG2(pubkey);
+
     const pairings = mcl.precomputedMillerLoop2mixed(
-        messageG1,
-        pubkeyG2,
+        message,
+        pubkey,
         signature,
         negG2
     );
     return mcl.finalExp(pairings).isOne();
 }
 
-export function verifyMultiple(
-    aggSignature: solG1,
-    pubkeys: solG2[],
-    messages: Message[]
+export function verifyMultipleRaw(
+    aggSignature: Signature,
+    pubkeys: PublicKey[],
+    messages: MessagePoint[]
 ): boolean {
     const size = pubkeys.length;
     if (size === 0) throw Error("number of public key is zero");
     if (size != messages.length)
         throw Error("number of public keys and messages must be equal");
     const negG2 = new mcl.PrecomputedG2(negativeG2());
-    const mclAggSignature = parseG1(aggSignature);
-    let accumulator = mcl.precomputedMillerLoop(mclAggSignature, negG2);
+    let accumulator = mcl.precomputedMillerLoop(aggSignature, negG2);
     for (let i = 0; i < size; i++) {
-        const messageG1 = parseG1(messages[i]);
-        const pubkeyG2 = parseG2(pubkeys[i]);
-        accumulator = mcl.mul(accumulator, mcl.millerLoop(messageG1, pubkeyG2));
+        accumulator = mcl.mul(
+            accumulator,
+            mcl.millerLoop(messages[i], pubkeys[i])
+        );
     }
     return mcl.finalExp(accumulator).isOne();
 }
 
-export function aggreagate(signatures: Signature[]): solG1 {
+export function aggregateRaw(signatures: Signature[]): Signature {
     let aggregated = new mcl.G1();
     for (const sig of signatures) {
         aggregated = mcl.add(aggregated, sig);
     }
     aggregated.normalize();
-    return g1ToHex(aggregated);
-}
-
-export function newG1(): solG1 {
-    const g1 = new mcl.G1();
-    return g1ToHex(g1);
-}
-
-export function newG2(): solG2 {
-    const g2 = new mcl.G2();
-    return g2ToHex(g2);
+    return aggregated;
 }
 
 export function randFr(): mclFR {

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -17,6 +17,7 @@ import {
     verifyMultipleRaw,
     hashToPoint,
     init,
+    parseFr,
 } from "./mcl";
 
 export interface BlsSignerInterface {
@@ -73,13 +74,13 @@ export class BlsVerifier {
 }
 
 export class BlsSigner extends BlsVerifier implements BlsSignerInterface {
-    static async getSigner(domain: Domain) {
+    static async getSigner(domain: Domain, secretHex?: string) {
         await init();
-        const secret = randFr();
+        const secret = secretHex ? parseFr(secretHex) : randFr();
         return new BlsSigner(domain, secret);
     }
     private _pubkey: PublicKey;
-    constructor(public domain: Domain, private secret: SecretKey) {
+    private constructor(public domain: Domain, private secret: SecretKey) {
         super(domain);
         this._pubkey = getPubkey(secret);
     }

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -73,14 +73,22 @@ export class BlsVerifier {
     }
 }
 
-export class BlsSigner extends BlsVerifier implements BlsSignerInterface {
-    static async getSigner(domain: Domain, secretHex?: string) {
+export class BlsSignerFactory {
+    static async new() {
         await init();
+        return new BlsSignerFactory();
+    }
+    private constructor() {}
+
+    public getSigner(domain: Domain, secretHex?: string) {
         const secret = secretHex ? parseFr(secretHex) : randFr();
         return new BlsSigner(domain, secret);
     }
+}
+
+class BlsSigner extends BlsVerifier implements BlsSignerInterface {
     private _pubkey: PublicKey;
-    private constructor(public domain: Domain, private secret: SecretKey) {
+    constructor(public domain: Domain, private secret: SecretKey) {
         super(domain);
         this._pubkey = getPubkey(secret);
     }

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -1,3 +1,4 @@
+import { NullSigner } from "./exceptions";
 import {
     solG2,
     Domain,
@@ -28,22 +29,23 @@ export interface BlsSignerInterface {
     ): boolean;
 }
 
+// Useful when your real signer is not loaded but need a placeholder
 export class NullBlsSinger implements BlsSignerInterface {
     get pubkey(): solG2 {
-        throw new Error("NullBlsSinger has no public key");
+        throw new NullSigner("NullSinger has no public key");
     }
     sign(message: string): solG1 {
-        throw new Error("NullBlsSinger dosen't sign");
+        throw new NullSigner("NullSinger dosen't sign");
     }
     verify(signature: solG1, pubkey: solG2, message: string): boolean {
-        throw new Error("NullBlsSinger dosen't verify");
+        throw new NullSigner("NullSinger dosen't verify");
     }
     verifyMultiple(
         aggSignature: solG1,
         pubkeys: solG2[],
         messages: string[]
     ): boolean {
-        throw new Error("NullBlsSinger dosen't verify");
+        throw new NullSigner("NullSinger dosen't verify");
     }
 }
 

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -1,0 +1,96 @@
+import {
+    solG2,
+    Domain,
+    getPubkey,
+    g2ToHex,
+    sign,
+    g1ToHex,
+    aggregateRaw,
+    solG1,
+    SecretKey,
+    randFr,
+    PublicKey,
+    parseG1,
+    parseG2,
+    verifyRaw,
+    verifyMultipleRaw,
+    hashToPoint,
+} from "./mcl";
+
+export interface BlsSignerInterface {
+    pubkey: solG2;
+    sign(message: string): solG1;
+    verify(signature: solG1, pubkey: solG2, message: string): boolean;
+    verifyMultiple(
+        aggSignature: solG1,
+        pubkeys: solG2[],
+        messages: string[]
+    ): boolean;
+}
+
+export class NullBlsSinger implements BlsSignerInterface {
+    get pubkey(): solG2 {
+        throw new Error("NullBlsSinger has no public key");
+    }
+    sign(message: string): solG1 {
+        throw new Error("NullBlsSinger dosen't sign");
+    }
+    verify(signature: solG1, pubkey: solG2, message: string): boolean {
+        throw new Error("NullBlsSinger dosen't verify");
+    }
+    verifyMultiple(
+        aggSignature: solG1,
+        pubkeys: solG2[],
+        messages: string[]
+    ): boolean {
+        throw new Error("NullBlsSinger dosen't verify");
+    }
+}
+
+export const nullBlsSigner = new NullBlsSinger();
+
+export class BlsVerifier {
+    constructor(public domain: Domain) {}
+    public verify(signature: solG1, pubkey: solG2, message: string) {
+        const signatureG1 = parseG1(signature);
+        const pubkeyG2 = parseG2(pubkey);
+        const messagePoint = hashToPoint(message, this.domain);
+        return verifyRaw(signatureG1, pubkeyG2, messagePoint);
+    }
+    public verifyMultiple(
+        aggSignature: solG1,
+        pubkeys: solG2[],
+        messages: string[]
+    ) {
+        const signatureG1 = parseG1(aggSignature);
+        const pubkeyG2s = pubkeys.map(parseG2);
+        const messagePoints = messages.map((m) => hashToPoint(m, this.domain));
+        return verifyMultipleRaw(signatureG1, pubkeyG2s, messagePoints);
+    }
+}
+
+export class BlsSigner extends BlsVerifier implements BlsSignerInterface {
+    static new(domain: Domain) {
+        const secret = randFr();
+        return new BlsSigner(domain, secret);
+    }
+    private _pubkey: PublicKey;
+    constructor(public domain: Domain, private secret: SecretKey) {
+        super(domain);
+        this._pubkey = getPubkey(secret);
+    }
+    get pubkey(): solG2 {
+        return g2ToHex(this._pubkey);
+    }
+
+    public sign(message: string): solG1 {
+        const { signature } = sign(message, this.secret, this.domain);
+        return g1ToHex(signature);
+    }
+}
+
+export function aggregate(signatures: solG1[]): solG1 {
+    const signatureG1s = signatures.map((s) => parseG1(s));
+    const aggregated = aggregateRaw(signatureG1s);
+    return g1ToHex(aggregated);
+}

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -16,6 +16,7 @@ import {
     verifyRaw,
     verifyMultipleRaw,
     hashToPoint,
+    init,
 } from "./mcl";
 
 export interface BlsSignerInterface {
@@ -72,7 +73,8 @@ export class BlsVerifier {
 }
 
 export class BlsSigner extends BlsVerifier implements BlsSignerInterface {
-    static new(domain: Domain) {
+    static async getSigner(domain: Domain) {
+        await init();
         const secret = randFr();
         return new BlsSigner(domain, secret);
     }

--- a/test/hashToField.test.ts
+++ b/test/hashToField.test.ts
@@ -98,10 +98,9 @@ describe("Hash to Field", () => {
             "0x09b6a2dec1f1b0747c73332e5147ecacde20767f28a9b68261713bed9a1d2432";
         const expectedY =
             "0x0cb70ff0b1bdb5d30006bd0cc03dc2c071dcff0daea886c9793f304c695c1bc6";
-        const dst = "xxx";
+        const dst = Uint8Array.from(Buffer.from("xxx", "utf8"));
         const msg = "0x616263";
-        mcl.setDomain(dst);
-        const p = mcl.hashToPoint(msg);
+        const p = mcl.hashToPoint(msg, dst);
         const [x, y] = mcl.g1ToHex(p);
         assert.equal(x, expectedX);
         assert.equal(y, expectedY);

--- a/test/signer.test.ts
+++ b/test/signer.test.ts
@@ -1,6 +1,6 @@
 import { assert } from "chai";
 import { arrayify, formatBytes32String, keccak256 } from "ethers/lib/utils";
-import { aggregate, BlsSigner } from "../src/signer";
+import { aggregate, BlsSignerFactory } from "../src/signer";
 
 describe("BLS Signer", async () => {
     // Domain is a data that signer and verifier must agree on
@@ -11,10 +11,12 @@ describe("BLS Signer", async () => {
         // message should be a hex string
         const message = formatBytes32String("Hello");
 
+        const factory = await BlsSignerFactory.new();
+
         // A signer can be instantiate with new key pair generated
-        const signer = await BlsSigner.getSigner(DOMAIN);
+        const signer = factory.getSigner(DOMAIN);
         // ... or with an existing secret
-        const signer2 = await BlsSigner.getSigner(DOMAIN, "0xabcd");
+        const signer2 = factory.getSigner(DOMAIN, "0xabcd");
 
         const signature = signer.sign(message);
 
@@ -22,14 +24,15 @@ describe("BLS Signer", async () => {
         assert.isFalse(signer.verify(signature, signer2.pubkey, message));
     });
     it("verify aggregated signature", async function () {
+        const factory = await BlsSignerFactory.new();
         const rawMessages = ["Hello", "how", "are", "you"];
-        const signers: BlsSigner[] = [];
+        const signers = [];
         const messages = [];
         const pubkeys = [];
         const signatures = [];
         for (const raw of rawMessages) {
             const message = formatBytes32String(raw);
-            const signer = await BlsSigner.getSigner(DOMAIN);
+            const signer = factory.getSigner(DOMAIN);
             const signature = signer.sign(message);
             signers.push(signer);
             messages.push(message);

--- a/test/signer.test.ts
+++ b/test/signer.test.ts
@@ -1,0 +1,48 @@
+import { assert } from "chai";
+import { arrayify, formatBytes32String, keccak256 } from "ethers/lib/utils";
+import { aggregate, BlsSigner } from "../src/signer";
+import { init } from "../src/mcl";
+
+// This is the raw API, it is not recommended to use it directly in your application
+
+describe("BLS Signer", async () => {
+    // Domain is a data that signer and verifier must agree on
+    // A verifier considers a signature invalid if it is signed with a different domain
+    const DOMAIN = arrayify(keccak256("0x1234ABCD"));
+    before(async function () {
+        // The libaray needs to be inititalized before using it
+        await init();
+    });
+
+    it("verify single signature", async function () {
+        // mcl.sign takes hex string as input, so the raw string needs to be encoded
+        const message = formatBytes32String("Hello");
+
+        // The `new` method creates a key pair
+        const signer = BlsSigner.new(DOMAIN);
+
+        const signature = signer.sign(message);
+
+        assert.isTrue(signer.verify(signature, signer.pubkey, message));
+    });
+    it("verify aggregated signature", async function () {
+        const rawMessages = ["Hello", "how", "are", "you"];
+        const signers: BlsSigner[] = [];
+        const messages = [];
+        const pubkeys = [];
+        const signatures = [];
+        for (const raw of rawMessages) {
+            const message = formatBytes32String(raw);
+            const signer = BlsSigner.new(DOMAIN);
+            const signature = signer.sign(message);
+            signers.push(signer);
+            messages.push(message);
+            pubkeys.push(signer.pubkey);
+            signatures.push(signature);
+        }
+        const aggSignature = aggregate(signatures);
+        assert.isTrue(
+            signers[0].verifyMultiple(aggSignature, pubkeys, messages)
+        );
+    });
+});

--- a/test/signer.test.ts
+++ b/test/signer.test.ts
@@ -1,7 +1,6 @@
 import { assert } from "chai";
 import { arrayify, formatBytes32String, keccak256 } from "ethers/lib/utils";
 import { aggregate, BlsSigner } from "../src/signer";
-import { init } from "../src/mcl";
 
 // This is the raw API, it is not recommended to use it directly in your application
 
@@ -9,17 +8,13 @@ describe("BLS Signer", async () => {
     // Domain is a data that signer and verifier must agree on
     // A verifier considers a signature invalid if it is signed with a different domain
     const DOMAIN = arrayify(keccak256("0x1234ABCD"));
-    before(async function () {
-        // The libaray needs to be inititalized before using it
-        await init();
-    });
 
     it("verify single signature", async function () {
         // mcl.sign takes hex string as input, so the raw string needs to be encoded
         const message = formatBytes32String("Hello");
 
         // The `new` method creates a key pair
-        const signer = BlsSigner.new(DOMAIN);
+        const signer = await BlsSigner.getSigner(DOMAIN);
 
         const signature = signer.sign(message);
 
@@ -33,7 +28,7 @@ describe("BLS Signer", async () => {
         const signatures = [];
         for (const raw of rawMessages) {
             const message = formatBytes32String(raw);
-            const signer = BlsSigner.new(DOMAIN);
+            const signer = await BlsSigner.getSigner(DOMAIN);
             const signature = signer.sign(message);
             signers.push(signer);
             messages.push(message);

--- a/test/signer.test.ts
+++ b/test/signer.test.ts
@@ -15,10 +15,13 @@ describe("BLS Signer", async () => {
 
         // The `new` method creates a key pair
         const signer = await BlsSigner.getSigner(DOMAIN);
+        // Signer can also be initiated with an existing secret
+        const signer2 = await BlsSigner.getSigner(DOMAIN, "0xabcd");
 
         const signature = signer.sign(message);
 
         assert.isTrue(signer.verify(signature, signer.pubkey, message));
+        assert.isFalse(signer.verify(signature, signer2.pubkey, message));
     });
     it("verify aggregated signature", async function () {
         const rawMessages = ["Hello", "how", "are", "you"];

--- a/test/signer.test.ts
+++ b/test/signer.test.ts
@@ -2,20 +2,18 @@ import { assert } from "chai";
 import { arrayify, formatBytes32String, keccak256 } from "ethers/lib/utils";
 import { aggregate, BlsSigner } from "../src/signer";
 
-// This is the raw API, it is not recommended to use it directly in your application
-
 describe("BLS Signer", async () => {
     // Domain is a data that signer and verifier must agree on
     // A verifier considers a signature invalid if it is signed with a different domain
     const DOMAIN = arrayify(keccak256("0x1234ABCD"));
 
     it("verify single signature", async function () {
-        // mcl.sign takes hex string as input, so the raw string needs to be encoded
+        // message should be a hex string
         const message = formatBytes32String("Hello");
 
-        // The `new` method creates a key pair
+        // A signer can be instantiate with new key pair generated
         const signer = await BlsSigner.getSigner(DOMAIN);
-        // Signer can also be initiated with an existing secret
+        // ... or with an existing secret
         const signer2 = await BlsSigner.getSigner(DOMAIN, "0xabcd");
 
         const signature = signer.sign(message);


### PR DESCRIPTION
### What's wrong

We currently set Domain as a global variable. This worked well in tests, and it was kind of immutable once its value is assigned. But we want more visibility of how and why the domain is used.

### How we are fixing it

We introduce a signer API that holds the domain and keys for us. See `test/signer.test.ts` for its usage.

The Signer API has these advantages:

- It fixes the domain issue 
- creates a similar dev experience as the Signer class of ethers.js. 
- The low-level mcl.ts can focus on handling the mcl objects, and the BlsSigner can focus on translating Solidity structs to mcl objects.

### Note

This is a breaking change. We need to cut another release for it.