### PR TITLE
fix memory leak

### DIFF
--- a/src/mcl.ts
+++ b/src/mcl.ts
@@ -145,6 +145,8 @@ export function verifyRaw(
         signature,
         negG2
     );
+    // call this function to avoid memory leak
+    negG2.destroy();
     return mcl.finalExp(pairings).isOne();
 }
 
@@ -167,6 +169,8 @@ export function verifyMultipleRaw(
             mcl.millerLoop(messages[i], pubkeys[i])
         );
     }
+    // call this function to avoid memory leak
+    negG2.destroy();
     return mcl.finalExp(accumulator).isOne();
 }
 

--- a/test/signer.test.ts
+++ b/test/signer.test.ts
@@ -44,4 +44,20 @@ describe("BLS Signer", async () => {
             signers[0].verifyMultiple(aggSignature, pubkeys, messages)
         );
     });
+
+    it("can verify 1,000 times", async () => {
+        // message should be a hex string
+        const message = formatBytes32String("Hello");
+
+        const factory = await BlsSignerFactory.new();
+
+        // A signer can be instantiate with new key pair generated
+        const signer = factory.getSigner(DOMAIN);
+
+        const signature = signer.sign(message);
+
+        for (let i = 0; i < 1000; i++) {
+            assert.isTrue(signer.verify(signature, signer.pubkey, message));
+        }
+    })
 });

--- a/test/signer.test.ts
+++ b/test/signer.test.ts
@@ -59,5 +59,5 @@ describe("BLS Signer", async () => {
         for (let i = 0; i < 1000; i++) {
             assert.isTrue(signer.verify(signature, signer.pubkey, message));
         }
-    })
+    }).timeout(20000);
 });


### PR DESCRIPTION
### What's wrong

In the hubble client, if we call verify multiple times it would get an `invalid index into function table` error.

```
   RuntimeError: invalid index into function table
      at wasm-function[63]:0xd4e9
      at wasm-function[359]:0x48f06
      at wasm-function[361]:0x493d7
      at new exports.PrecomputedG2 (node_modules/mcl-wasm/mcl.js:674:13)
      at Object.verifyRaw (ts/mcl.ts:213:19)
```

### How can we fix it

Judging from the mcl test cases, we have to destroy the PrecompileG2 after using it. After adding the destroy function call, the bubble client's problem is fixed.

https://github.com/herumi/mcl-wasm/blob/b6b98ff2070cdb2af886857d0304b54a3a341947/test/test.js#L356