### PR TITLE
Bug: Some invalid signatures cause .verify to throw instead of returning false

### DIFF
--- a/test/signer.test.ts
+++ b/test/signer.test.ts
@@ -1,6 +1,7 @@
 import { assert } from "chai";
 import { arrayify, formatBytes32String, keccak256 } from "ethers/lib/utils";
-import { aggregate, BlsSignerFactory } from "../src/signer";
+import { solG1, solG2 } from "../src/mcl";
+import { aggregate, BlsSignerFactory, BlsVerifier } from "../src/signer";
 
 describe("BLS Signer", async () => {
     // Domain is a data that signer and verifier must agree on
@@ -43,5 +44,31 @@ describe("BLS Signer", async () => {
         assert.isTrue(
             signers[0].verifyMultiple(aggSignature, pubkeys, messages)
         );
+    });
+
+    it("rejects invalid signature", async function() {
+        const verifier = new BlsVerifier(arrayify(keccak256("0xfeedbee5")));
+
+        // Starting from a correctly signed example
+        const signature: solG1 = ["0x159647ae964ea7a386767ab1e41aa47652265bf031ab9d05b70bf5ad1a770a3c","0x0d46b38b1f72d7df1f88786272f0b3fea1c79e1c8515a165fe19939e031ced9e"];
+        const pubkey: solG2 = ["0x2836b6b13bd5ace9680634043f09fec8732b6e43939f7e4d2f76c03db0afce15","0x18496f68063e0be219b95a1d086279772a3bca0005aa1cb39eabde35d2d8d5f4","0x0ae7d6473913e4865cdeba81f88d3511acb461175f4e9ac7e8fe5e48bbc55c0f","0x075a3c3c825d516ed0b6014246e869d50f24be3affcac6f1814ee69429cd045d"];
+        const message = "0x0000000000000000000000000000000000000000000000000000000000066eeb000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000000000000000000000000000000000000008cd755f93e56c90e3d5803c036771cfcc12b7c537717ec640ce190aa48cd0019aad18112e6c16befa603de675c3e86a11228aab6";
+
+        assert.isTrue(verifier.verify(
+            signature,
+            pubkey,
+            message,
+        ));
+
+        // Change first hex digit of signature from 1 to 0 (to make it invalid)
+        const badSignature = signature.slice() as solG1;
+        badSignature[0] = `0x0${signature[0].slice(3)}`;
+
+        // This should just return false, but it throws :(
+        assert.isFalse(verifier.verify(
+            badSignature,
+            pubkey,
+            message,
+        ));
     });
 });


### PR DESCRIPTION
This PR adds a failing test showing an example of the bug.

```
➜  hubble-bls git:(invalid-sig-bug) ✗ npm test

> @thehubbleproject/bls@0.3.1-voltrevo.1 test
> mocha -r ts-node/register test/**/*.test.ts



  Hash to Field
    ✓ expand message
    ✓ hash to point

  BLS raw API
    ✓ parse g1
    ✓ parse g2
    ✓ load and dumps Fr
    ✓ load and dumps G1
    ✓ load and dumps G2
    ✓ verify single signature
    ✓ verify aggregated signature

  BLS Signer
    ✓ verify single signature (78ms)
    ✓ verify aggregated signature (84ms)
    1) rejects invalid signature


  11 passing (396ms)
  1 failing

  1) BLS Signer
       rejects invalid signature:
     Error: err _wrapInput 1 0x059647ae964ea7a386767ab1e41aa47652265bf031ab9d05b70bf5ad1a770a3c 0x0d46b38b1f72d7df1f88786272f0b3fea1c79e1c8515a165fe19939e031ced9e
      at /Users/andrew/workspaces/ethf/hubble-bls/node_modules/mcl-wasm/src/mcl.js:145:22
      at exports.G1._setter (node_modules/mcl-wasm/src/mcl.js:274:19)
      at exports.G1.setStr (node_modules/mcl-wasm/src/mcl.js:484:14)
      at Object.parseG1 (src/mcl.ts:219:8)
      at BlsVerifier.verify (src/signer.ts:59:29)
      at Context.<anonymous> (test/signer.test.ts:68:33)
      at processImmediate (node:internal/timers:464:21)
```