### PR TITLE
Bug: When calling verify repeatedly, it throws 'invalid index into function table' on the 459th call

### DIFF
--- a/test/signer.test.ts
+++ b/test/signer.test.ts
@@ -44,4 +44,20 @@ describe("BLS Signer", async () => {
             signers[0].verifyMultiple(aggSignature, pubkeys, messages)
         );
     });
+
+    it("can verify 1,000 times", async () => {
+        // message should be a hex string
+        const message = formatBytes32String("Hello");
+
+        const factory = await BlsSignerFactory.new();
+
+        // A signer can be instantiate with new key pair generated
+        const signer = factory.getSigner(DOMAIN);
+
+        const signature = signer.sign(message);
+
+        for (let i = 0; i < 1000; i++) {
+            assert.isTrue(signer.verify(signature, signer.pubkey, message));
+        }
+    })
 });


### PR DESCRIPTION
This PR adds a failing test showing an example of the bug.

```
➜  hubble-bls git:(verify-repeat-bug) ✗ npm test     

> @thehubbleproject/bls@0.3.0 test
> mocha -r ts-node/register test/**/*.test.ts



  Hash to Field
    ✓ expand message
    ✓ hash to point

  BLS raw API
    ✓ parse g1
    ✓ parse g2
    ✓ load and dumps Fr
    ✓ load and dumps G1
    ✓ load and dumps G2
    ✓ verify single signature
    ✓ verify aggregated signature

  BLS Signer
    ✓ verify single signature (79ms)
    ✓ verify aggregated signature (85ms)
    1) can verify 1,000 times


  11 passing (3s)
  1 failing

  1) BLS Signer
       can verify 1,000 times:
     RuntimeError: invalid index into function table
      at null.<anonymous> (wasm://wasm/0016c1e2:0:40904)
      at null.<anonymous> (wasm://wasm/0016c1e2:0:283387)
      at tb (wasm://wasm/0016c1e2:0:284504)
      at new exports.PrecomputedG2 (node_modules/mcl-wasm/src/mcl.js:664:13)
      at Object.verifyRaw (src/mcl.ts:140:19)
      at BlsSigner.verify (src/signer.ts:62:16)
      at Context.<anonymous> (test/signer.test.ts:60:34)
```