### PR TITLE
change behavior of parseFr and add setHashFr

### DIFF
--- a/src/mcl.ts
+++ b/src/mcl.ts
@@ -209,6 +209,13 @@ export function randG2(): solG2 {
 export function parseFr(hex: string) {
     if (!isHexString(hex)) throw new BadHex(`Expect hex but got ${hex}`);
     const fr = new mcl.Fr();
+    fr.setStr(hex);
+    return fr;
+}
+
+export function setHashFr(hex: string) {
+    if (!isHexString(hex)) throw new BadHex(`Expect hex but got ${hex}`);
+    const fr = new mcl.Fr();
     fr.setHashOf(hex);
     return fr;
 }

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -82,7 +82,11 @@ export class BlsSignerFactory {
     private constructor() {}
 
     public getSigner(domain: Domain, secretHex?: string) {
-        const secret = secretHex ? (secretHex.length == 66 ? parseFr(secretHex) : setHashFr(secretHex)) : randFr();
+        const secret = secretHex
+            ? secretHex.length == 66
+                ? parseFr(secretHex)
+                : setHashFr(secretHex)
+            : randFr();
         return new BlsSigner(domain, secret);
     }
 }

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -18,6 +18,7 @@ import {
     hashToPoint,
     init,
     parseFr,
+    setHashFr,
 } from "./mcl";
 
 export interface BlsSignerInterface {
@@ -81,7 +82,7 @@ export class BlsSignerFactory {
     private constructor() {}
 
     public getSigner(domain: Domain, secretHex?: string) {
-        const secret = secretHex ? parseFr(secretHex) : randFr();
+        const secret = secretHex ? (secretHex.length == 66 ? parseFr(secretHex) : setHashFr(secretHex)) : randFr();
         return new BlsSigner(domain, secret);
     }
 }


### PR DESCRIPTION
I was struggling a bit with the compatibility between the [Go](https://github.com/kilic/bn254/tree/master/bls) and this Typescript library. The issue is rather simple and occurs during loading of an existing secret. The `parseFr` method here does something slightly unexpected and calls `setHashOf` instead of `setStr` like in the other `parse*` methods in the package. This means you can never pass the scalar you want, but it always gets [sha hashed](https://github.com/herumi/mcl#how-do-i-set-the-hash-value-to-fr).

Hashing makes sense if you don't pass a 32 byte scalar, so I've added this again as a fallback, which should also preserve backwards compatibility for other apps relying on this behavior. 