### PR TITLE
Fix error when hexes of length 64 are used as signer secrets

### DIFF
--- a/src/signer.ts
+++ b/src/signer.ts
@@ -82,12 +82,23 @@ export class BlsSignerFactory {
     private constructor() {}
 
     public getSigner(domain: Domain, secretHex?: string) {
-        const secret = secretHex
-            ? secretHex.length == 66
-                ? parseFr(secretHex)
-                : setHashFr(secretHex)
-            : randFr();
+        const secret = this.getSecret(secretHex);
         return new BlsSigner(domain, secret);
+    }
+
+    private getSecret(secretHex?: string) {
+        if (!secretHex) {
+            // Generate a random secret
+            return randFr();
+        }
+
+        try {
+            // Attempt to directly parse the hex
+            return parseFr(secretHex);
+        } catch {
+            // If that fails, hash it
+            return setHashFr(secretHex);
+        }
     }
 }
 


### PR DESCRIPTION
Change behavior of signer secret parsing to do a direct Fr string set, with a fallback of hashing the secret input on error.
Add validateHex function.
Add wider range of secret values to signer tests.
Use mcl-wasm Typescript types instead of any.

Resolves https://github.com/thehubbleproject/hubble-bls/issues/27